### PR TITLE
fix(css): fix toolbar button sizes in markdown editor for IE6

### DIFF
--- a/staticfiles/css/main.css
+++ b/staticfiles/css/main.css
@@ -1524,7 +1524,7 @@ a.report_problem {
 .md-toolbar { margin-bottom: 5px; background: #bfe0ff; padding: 5px; border-bottom: 1px solid #215dc6; }
 .md-toolbar * { vertical-align: middle; }
 .md-textarea { width: 100%; box-sizing: border-box; }
-.md-btn { border: 1px solid #7aa0e6; background: #e0edff; padding: 2px 6px; font-size: 11px; cursor: pointer; font-family: Tahoma, Arial, sans-serif; }
+.md-btn { border: 1px solid #7aa0e6; background: #e0edff; padding: 2px 6px; font-size: 11px; cursor: pointer; font-family: Tahoma, Arial, sans-serif; overflow: visible; width: auto; }
 .md-btn:hover { background: #c8e1ff; }
 .md-btn-sep { border-left: 1px solid #215dc6; margin: 0 5px; }
 .md-btn-note { color: #0366d6; }


### PR DESCRIPTION
Before:

<img width="445" height="210" alt="fix-before" src="https://github.com/user-attachments/assets/847a1db2-9693-4b2c-bfe0-4e0f71d3e972" />

After:

<img width="446" height="198" alt="fix-after" src="https://github.com/user-attachments/assets/a240ccbf-bb31-42ca-810b-fed38f92ef51" />
