### PR TITLE
fix(adminui): remove CSS property

### DIFF
--- a/apps/marketplace/admin.py
+++ b/apps/marketplace/admin.py
@@ -563,7 +563,6 @@ class DistributionEditRequestAdmin(
 
     list_display = (
         "id",
-        "app",
         "target_distribution",
         "user",
         "status",

--- a/apps/marketplace/admin.py
+++ b/apps/marketplace/admin.py
@@ -444,7 +444,7 @@ class DistributionCreateAdmin(
     change_list_template = "admin/decline_forms/change_list_custom.html"
     change_form_template = "admin/decline_forms/change_form_custom.html"
 
-    list_display = ("id", "app", "version", "user", "status", "created_at")
+    list_display = ("app", "id", "version", "user", "status", "created_at")
     search_fields = ["app__title", "version", "user__username"]
     list_filter = SafeDeleteAdmin.list_filter + ["status", "created_at"]
     actions_detail = ["approve_request", "reject_request"]
@@ -563,6 +563,7 @@ class DistributionEditRequestAdmin(
 
     list_display = (
         "id",
+        "app",
         "target_distribution",
         "user",
         "status",

--- a/apps/marketplace/admin.py
+++ b/apps/marketplace/admin.py
@@ -444,7 +444,7 @@ class DistributionCreateAdmin(
     change_list_template = "admin/decline_forms/change_list_custom.html"
     change_form_template = "admin/decline_forms/change_form_custom.html"
 
-    list_display = ("app", "id", "version", "user", "status", "created_at")
+    list_display = ("id", "app", "version", "user", "status", "created_at")
     search_fields = ["app__title", "version", "user__username"]
     list_filter = SafeDeleteAdmin.list_filter + ["status", "created_at"]
     actions_detail = ["approve_request", "reject_request"]

--- a/staticfiles/css/admin_custom.css
+++ b/staticfiles/css/admin_custom.css
@@ -56,12 +56,6 @@ form table td input[type="password"] {
     border-radius: 6px !important;
 }
 
-
-#changelist-form table th:nth-child(3),
-#changelist-form table td:nth-child(3) {
-    display: none !important;
-}
-
 /* markdown toolbar adapted for unfold admin */
 .md-editor-container {
     width: 100%;


### PR DESCRIPTION
Названия приложений /admin/marketplace/distributioncreaterequests заместо их ID

Почему-то нельзя сделать и то и то, попросту выставляется на показ лишь первое из списка