### PR TITLE
fix(app): don't propagate event for "Developer's website" button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -143,7 +143,7 @@
                         </li>
 
                         {% if developer_site %}
-                        <li class="web" onclick="window.open('{{ developer_site }}', '_blank')">
+                        <li class="web" onclick="window.open('{{ developer_site }}', '_blank'); return false">
                             <a href="{{ developer_site }}" target="_blank">{% trans "BASE_SIDEBAR_APP_DEV_SITE" %}</a>
                         </li>
                         {% endif %}


### PR DESCRIPTION
Fixes #48, tested on Firefox 154 and Internet Explorer 6